### PR TITLE
大佬，发现您的项目引入了com.fasterxml.jackson.core:jackson-databind@2.9.10.3组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" 
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -58,7 +57,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.3</version>
+            <version>2.9.10.8</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：FasterXML jackson-databind反序列化漏洞(AnterosDBCPConfig gadget绕过)
缺陷组件：com.fasterxml.jackson.core:jackson-databind@2.9.10.3
漏洞编号：CVE-2020-9548
漏洞描述：FasterXML Jackson是美国FasterXML公司的一款适用于Java的数据处理工具。jackson-databind是其中的一个具有数据绑定功能的组件。
FasterXML jackson-databind 2.9.10.4之前的2.x版本中存在安全漏洞。攻击者可借助特制的请求利用该漏洞执行任意代码。
影响范围：[2.9.0, 2.9.10.4)
最小修复版本：2.9.10.8
缺陷组件引入路径：org.jenkins-ci.plugins:juxtapose@1.0.2->com.fasterxml.jackson.core:jackson-databind@2.9.10.3
```
另外我运行这个项目时，IDE的安全插件提示还有37个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pedb7d